### PR TITLE
Refresh CoverAlls badge image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 [![Build Status](https://travis-ci.com/swsnu/swpp2021-team4.svg?branch=main)](https://travis-ci.com/swsnu/swpp2021-team4)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=swsnu_swpp2021-team4&metric=alert_status)](https://sonarcloud.io/dashboard?id=swsnu_swpp2021-team4)
-[![Coverage Status](https://coveralls.io/repos/github/swsnu/swpp2021-team4/badge.svg?branch=main)](https://coveralls.io/github/swsnu/swpp2021-team4?branch=main)
+[![Coverage Status](https://coveralls.io/repos/github/swsnu/swpp2021-team4/badge.svg?branch=main&service=github)](https://coveralls.io/github/swsnu/swpp2021-team4?branch=main&service=github)


### PR DESCRIPTION
This PR resolves the error with CoverAlls badge in the README.md file.

Check the branch page below:
https://github.com/swsnu/swpp2021-team4/tree/coveralls-badge

You can see the badge image has been updated.

Check the issue for the reference:
https://github.com/lemurheavy/coveralls-public/issues/971#issuecomment-338942441